### PR TITLE
Update 4.2 with document title conventions

### DIFF
--- a/Documentation-Norms.md
+++ b/Documentation-Norms.md
@@ -244,12 +244,44 @@ TBSL
 
 ## 4.2 Assign Work Product Name
 
-Once the need for a work product is established, the next step in creating a new work product is to name the document and create a shorthand for it. Give some thought to the product name when requesting a starter document, as that name will live on essentially forever. Consultation with the associated SC co-chairs is recommended, as well as familiarity with the _[OASIS Naming Directives](http://docs.oasis-open.org/specGuidelines/ndr/namingDirectives.html)_. Consultation with the OASIS TC Administration team is also helpful, as they can assist with applying the naming directives and help avoid collisions with the names of other OASIS products.
+Once the need for a work product is established, the next
+step in creating a new work product is to name the document
+and create a shorthand for it. Give some thought to the
+product name when requesting a starter document, as that
+name will live on essentially forever. Consultation with the
+associated SC co-chairs is recommended, as well as
+familiarity with the _[OASIS Naming
+Directives](http://docs.oasis-open.org/specGuidelines/ndr/namingDirectives.html)_.
+Consultation with the OASIS TC Administration team is also
+helpful, as they can assist with applying the naming
+directives and help avoid collisions with the names of other
+OASIS products.
 
-Since the TC name (i.e., "openc2") is already included in the URLs and GitHub repo names that OASIS assigns there is no need to include "openc2" or "oc2" in the shorthand name for the product (a lesson learned since the TC's first work products were named). A useful convention is to include the document type, so the following patterns are recommended (NOTE:  The initial actuator profile for stateless packet filtering and transfer specification for HTTPS do not follow these patterns, but the patterns are recommended for new specifications. If a new type of document is needed, the co-chairs of the associated subcommittee should be involved in determining the naming pattern for the new document type.):
+The TC's work products can be broken into over-arching
+documents (e.g., Language Specification, Architecture Specification) that
+define OpenC2 overall, and supporting documents (e.g.,
+actuator profiles, transfer specifications) that address
+specific features and functions. To provide for consistency,
+the following principles apply:
+ - Overarching documents should spell out OpenC2 in their titles.
+ - Supporting documents don't need to do so as they are
+   dependent on the overarching documents.
+
+The following example titles illustrate the application of
+these principals:
+
+- Open Command and Control (OpenC2) Language Specification
+- Open Command and Control (OpenC2) Architecture Specification
+- OpenC2 Actuator Profile for _cyberfunction_
+- OpenC2 Transfer Specification for _protocol_
+
+
+Since the TC name (i.e., "openc2") is already included in the URLs and GitHub repo names that OASIS assigns there is no need to include "openc2" or "oc2" in the shorthand name for the product (a lesson learned since the TC's first work products were named). A useful convention is to include the document type, so the following patterns are recommended:
 
 * Actuator profiles:  `ap-<function shorthand>`
 * Transfer specifications:  `transf-<protocol shorthand>`
+
+> NOTE:  The initial actuator profile for stateless packet filtering and transfer specification for HTTPS do not follow these patterns, but the patterns are recommended for new specifications. If a new type of document is needed, the co-chairs of the associated subcommittee should be involved in determining the naming pattern for the new document type.
 
 As an example, an actuator profile for anti-virus might have the shorthand of "ap-av", leading to:
 


### PR DESCRIPTION
Capture discussion from Slack & email regarding standard formats for document titles, plus other minor changes to Section 4.2. Addresses issue #29.