### PR TITLE
Work Product List Updates

### DIFF
--- a/Work-Product-List.md
+++ b/Work-Product-List.md
@@ -6,7 +6,8 @@
 |:---:|:----:|:-----:|:----:|:-----:|
 | [oc2ls](https://github.com/oasis-tcs/openc2-oc2ls) | Language Specification | [CS02](https://docs.oasis-open.org/openc2/oc2ls/v1.0/oc2ls-v1.0.html) | Toby Considine<br>Duncan Sparrell<br>_Jason Romano_ | Toby Considine<br>Duncan Sparrell<br>Drew Varner |
 | [oc2arch](https://github.com/oasis-tcs/oc2arch) | Architecture Specification | | Duncan Sparrell<br>Dan Johnson | Duncan Sparrell<br>Toby Considine<br>Joe Brule<br>David Lemire |
-| [jadn](https://github.com/oasis-tcs/openc2-jadn) | JSON Abstract Data Notation | | David Kemp | David Kemp<br>Duncan Sparrell<br>Joe Brule |
+| [jadn](https://github.com/oasis-tcs/openc2-jadn) | JSON Abstract Data Notation | [CS01](https://docs.oasis-open.org/openc2/jadn/v1.0/cs01/jadn-v1.0-cs01.html) | David Kemp | David Kemp<br>Duncan Sparrell<br>Joe Brule |
+| [jadn-im](https://github.com/oasis-tcs/openc2-jadn-im) | Information Modeling with JADN (CN) | | David Kemp | David Kemp<br>Dan Johnson |
 | [slpf](https://github.com/oasis-tcs/openc2-apsc-stateless-packet-filter) | Stateless Packet Filter | [CS01](https://docs.oasis-open.org/openc2/oc2slpf/v1.0/oc2slpf-v1.0.html) | Joe Brule<br>Duncan Sparrell<br>Alex Everett | David Kemp<br>Alex Everett<br>Duncan Sparrell<br>Joe Brule |
 | [sbom](https://github.com/oasis-tcs/openc2-ap-sbom) | Software Bill of Materials | | Duncan Sparrell | Duncan Sparrell<br>Alex Everett<br>David Kemp |
 | [sfpf](https://github.com/oasis-tcs/openc2-ap-sfpf) | Stateful Packet Filter | | Alex Everett<br>Vasileios Mavroeidis | Alex Everett<br>David Kemp<br>Vasileios Mavroeidis |

--- a/Work-Product-List.md
+++ b/Work-Product-List.md
@@ -1,24 +1,26 @@
 # OpenC2 TC Work Products
 
 > Names in _italics_ are individuals who are no longer TC members.
+> 
+> The TC's operating convention is that the write team for repo includes the work product editors, TC Co-Chairs, and TC Secretary.
 
 | Repository | Title | Recent | Editors | GH Repo<br>Write Team |
 |:---:|:----:|:-----:|:----:|:-----:|
-| [oc2ls](https://github.com/oasis-tcs/openc2-oc2ls) | Language Specification | [CS02](https://docs.oasis-open.org/openc2/oc2ls/v1.0/oc2ls-v1.0.html) | Toby Considine<br>Duncan Sparrell<br>_Jason Romano_ | Toby Considine<br>Duncan Sparrell<br>Drew Varner |
-| [oc2arch](https://github.com/oasis-tcs/oc2arch) | Architecture Specification | | Duncan Sparrell<br>Dan Johnson | Duncan Sparrell<br>Toby Considine<br>Joe Brule<br>David Lemire |
-| [jadn](https://github.com/oasis-tcs/openc2-jadn) | JSON Abstract Data Notation | [CS01](https://docs.oasis-open.org/openc2/jadn/v1.0/cs01/jadn-v1.0-cs01.html) | David Kemp | David Kemp<br>Duncan Sparrell<br>Joe Brule |
-| [jadn-im](https://github.com/oasis-tcs/openc2-jadn-im) | Information Modeling with JADN (CN) | | David Kemp | David Kemp<br>Dan Johnson |
-| [slpf](https://github.com/oasis-tcs/openc2-apsc-stateless-packet-filter) | Stateless Packet Filter | [CS01](https://docs.oasis-open.org/openc2/oc2slpf/v1.0/oc2slpf-v1.0.html) | Joe Brule<br>Duncan Sparrell<br>Alex Everett | David Kemp<br>Alex Everett<br>Duncan Sparrell<br>Joe Brule |
-| [sbom](https://github.com/oasis-tcs/openc2-ap-sbom) | Software Bill of Materials | | Duncan Sparrell | Duncan Sparrell<br>Alex Everett<br>David Kemp |
-| [sfpf](https://github.com/oasis-tcs/openc2-ap-sfpf) | Stateful Packet Filter | | Alex Everett<br>Vasileios Mavroeidis | Alex Everett<br>David Kemp<br>Vasileios Mavroeidis |
-| [ids](https://github.com/oasis-tcs/openc2-ap-ids) | Intrusion Detection Systems | | Duncan Sparrell | Duncan Sparrell |
-| [honeypots](https://github.com/oasis-tcs/openc2-ap-honeypots) | Honeypots | | Alex Everett | Alex Everett<br>David Kemp |
-| [edr](https://github.com/oasis-tcs/openc2-ap-edr) | Endpoint Detection & Response | | Vasileios Mavroeidis<br>Martin Evandt | Vasileios Mavroeidis<br>Martin Evandt<br>Alex Everett<br>David Kemp |
-| [pf](https://github.com/oasis-tcs/openc2-ap-pf) | Packet Filter | | Alex Everett | Alex Everett<br>David Kemp<br>Vasileios Mavroeidis |
-| [av](https://github.com/oasis-tcs/openc2-ap-av) | Anti-Virus | | Alex Everett<br>David Kemp<br>Vasileios Mavroeidis | Alex Everett<br>David Kemp<br>Vasileios Mavroeidis |
-| [https](https://github.com/oasis-tcs/openc2-transf-http) | HTTPS Transfer Specification | [CS01](https://docs.oasis-open.org/openc2/open-impl-https/v1.0/open-impl-https-v1.0.html) | David Lemire<br>Joe Brule | David Lemire<br>Joe Brule |
+| [oc2ls](https://github.com/oasis-tcs/openc2-oc2ls) | Language Specification | [CS02](https://docs.oasis-open.org/openc2/oc2ls/v1.0/oc2ls-v1.0.html) | Toby Considine<br>Duncan Sparrell<br>_Jason Romano_ | Toby Considine<br>Duncan Sparrell<br>Drew Varner<br>David Lemire |
+| [oc2arch](https://github.com/oasis-tcs/oc2arch) | Architecture Specification | | Duncan Sparrell<br>Dan Johnson | Duncan Sparrell<br>Dan Johnson<br>Toby Considine<br>David Lemire |
+| [jadn](https://github.com/oasis-tcs/openc2-jadn) | JSON Abstract Data Notation | [CS01](https://docs.oasis-open.org/openc2/jadn/v1.0/cs01/jadn-v1.0-cs01.html) | David Kemp | David Kemp<br>Duncan Sparrell |
+| [jadn-im](https://github.com/oasis-tcs/openc2-jadn-im) | Information Modeling with JADN (CN) | | David Kemp<br>Dan Johnson | David Kemp<br>Dan Johnson<br>Duncan Sparrell<br>David Lemire |
+| [slpf](https://github.com/oasis-tcs/openc2-apsc-stateless-packet-filter) | Stateless Packet Filter | [CS01](https://docs.oasis-open.org/openc2/oc2slpf/v1.0/oc2slpf-v1.0.html) | Duncan Sparrell<br>Alex Everett<br>_Joe Brule_ | David Kemp<br>Alex Everett<br>Duncan Sparrell<br>David Lemire |
+| [sbom](https://github.com/oasis-tcs/openc2-ap-sbom) | Software Bill of Materials | | Duncan Sparrell | Duncan Sparrell<br>Alex Everett<br>David Kemp<br>David Lemire |
+| [sfpf](https://github.com/oasis-tcs/openc2-ap-sfpf) | Stateful Packet Filter | | Alex Everett<br>Vasileios Mavroeidis | Alex Everett<br>David Kemp<br>Vasileios Mavroeidis<br>Duncan Sparrell<br>David Lemire |
+| [ids](https://github.com/oasis-tcs/openc2-ap-ids) | Intrusion Detection Systems | | Duncan Sparrell | Duncan Sparrell<br>David Lemire |
+| [honeypots](https://github.com/oasis-tcs/openc2-ap-honeypots) | Honeypots | | Alex Everett | Alex Everett<br>David Kemp<br>Duncan Sparrell<br>David Lemire |
+| [edr](https://github.com/oasis-tcs/openc2-ap-edr) | Endpoint Detection & Response | | Vasileios Mavroeidis<br>Martin Evandt | Vasileios Mavroeidis<br>Martin Evandt<br>Alex Everett<br>David Kemp<br>Duncan Sparrell<br>David Lemire |
+| [pf](https://github.com/oasis-tcs/openc2-ap-pf) | Packet Filter | | Alex Everett | Alex Everett<br>David Kemp<br>Vasileios Mavroeidis<br>Duncan Sparrell<br>David Lemire |
+| [av](https://github.com/oasis-tcs/openc2-ap-av) | Anti-Virus | | Alex Everett<br>David Kemp<br>Vasileios Mavroeidis | Alex Everett<br>David Kemp<br>Vasileios Mavroeidis<br>Duncan Sparrell<br>David Lemire |
+| [https](https://github.com/oasis-tcs/openc2-transf-http) | HTTPS Transfer Specification | [CS01](https://docs.oasis-open.org/openc2/open-impl-https/v1.0/open-impl-https-v1.0.html) | David Lemire<br>_Joe Brule_ | David Lemire<br>Duncan Sparrell |
 | [http](https://github.com/oasis-tcs/openc2-transf-http) | HTTP Transfer Specification | | David Lemire<br>Duncan Sparrell | David Lemire<br>Duncan Sparrell |
-| [mqtt](https://github.com/oasis-tcs/openc2-transf-mqtt) | MQTT Transfer Specification | | David Lemire | David Lemire<br>Joe Brule |
-| [odxl](https://github.com/oasis-tcs/openc2-transf-odxl) | OpenDXL Transfer Specification | | Duncan Sparrell<br>_Scott MacGregor_ | David Lemire<br>Duncan Sparrell<br>Joe Brule |
-| [lc](https://github.com/oasis-tcs/openc2-ap-lc) | Log Collector | | Alex Everett<br>David Kemp | Alex Everett<br>David Kemp |
+| [mqtt](https://github.com/oasis-tcs/openc2-transf-mqtt) | MQTT Transfer Specification | | David Lemire | David Lemire<br>Duncan Sparrell |
+| [odxl](https://github.com/oasis-tcs/openc2-transf-odxl) | OpenDXL Transfer Specification | | Duncan Sparrell<br>_Scott MacGregor_ | David Lemire<br>Duncan Sparrell |
+| [lc](https://github.com/oasis-tcs/openc2-ap-lc) | Log Collector | | Alex Everett<br>David Kemp | Alex Everett<br>David Kemp<br>Duncan Sparrell<br>David Lemire |
 


### PR DESCRIPTION
- Add link to recently published JADN CS
- Add JADN Information Modeling CN to the list
- Mark Joe Brule as former TC member in editor column
- Remove Joe Brule from write team column
- General updating of write team membership
- Added note about TC convention of including editors, co-chairs, and secretary on write teams