### PR TITLE
Update / reorganize work products list

### DIFF
--- a/Work-Product-List.md
+++ b/Work-Product-List.md
@@ -1,25 +1,41 @@
 # OpenC2 TC Work Products
 
-> Names in _italics_ are individuals who are no longer TC members.
-> 
-> The TC's operating convention is that the write team for each repo includes the work product editors, TC Co-Chairs, and TC Secretary.
+The TC's operating convention is that the write team for each
+repo includes the work product editors, TC Co-Chairs, and TC
+Secretary.
+
+Names in _italics_ are individuals who are no longer TC members.
+
+## OASIS Published Specifications
+
+Use the _Current_ link for the latest OASIS published version;
+in-development versions can be found under the working branch at
+each  _Repository_ link.
+
+| Repository | Title | Current | Editors | GH Repo<br>Write Team |
+|:---:|:----:|:-----:|:----:|:-----:|
+| [oc2ls](https://github.com/oasis-tcs/openc2-oc2ls) | Language Specification, v1.0 | [CS02](https://docs.oasis-open.org/openc2/oc2ls/v1.0/oc2ls-v1.0.html) | Toby Considine<br>Duncan Sparrell<br>_Jason Romano_ | Toby Considine<br>Duncan Sparrell<br>Drew Varner<br>David Lemire |
+| [jadn](https://github.com/oasis-tcs/openc2-jadn) | JSON Abstract Data Notation, v1.0 | [CS01](https://docs.oasis-open.org/openc2/jadn/v1.0/cs01/jadn-v1.0-cs01.html) | David Kemp | David Kemp<br>Duncan Sparrell |
+| [slpf](https://github.com/oasis-tcs/openc2-apsc-stateless-packet-filter) | Stateless Packet Filter, v1.0 | [CS01](https://docs.oasis-open.org/openc2/oc2slpf/v1.0/oc2slpf-v1.0.html) | Duncan Sparrell<br>Alex Everett<br>_Joe Brule_ | David Kemp<br>Alex Everett<br>Duncan Sparrell<br>David Lemire |
+| [https](https://github.com/oasis-tcs/openc2-impl-https) | HTTPS Transfer Specification, v1.1 | [CS01](https://docs.oasis-open.org/openc2/open-impl-https/v1.1/cs01/open-impl-https-v1.1-cs01.html) | David Lemire<br>_Joe Brule_ | David Lemire<br>Duncan Sparrell |
+| [mqtt](https://github.com/oasis-tcs/openc2-transf-mqtt) | MQTT Transfer Specification, v1.0 | [CS01](https://docs.oasis-open.org/openc2/transf-mqtt/v1.0/transf-mqtt-v1.0.html) | David Lemire | David Lemire<br>Duncan Sparrell |
+
+
+## Work In Progress
+This list is presented alphabetically by work product title.
 
 | Repository | Title | Recent | Editors | GH Repo<br>Write Team |
 |:---:|:----:|:-----:|:----:|:-----:|
-| [oc2ls](https://github.com/oasis-tcs/openc2-oc2ls) | Language Specification | [CS02](https://docs.oasis-open.org/openc2/oc2ls/v1.0/oc2ls-v1.0.html) | Toby Considine<br>Duncan Sparrell<br>_Jason Romano_ | Toby Considine<br>Duncan Sparrell<br>Drew Varner<br>David Lemire |
-| [oc2arch](https://github.com/oasis-tcs/openc2-oc2arch) | Architecture Specification | | Duncan Sparrell<br>Dan Johnson | Duncan Sparrell<br>Dan Johnson<br>Toby Considine<br>David Lemire |
-| [jadn](https://github.com/oasis-tcs/openc2-jadn) | JSON Abstract Data Notation | [CS01](https://docs.oasis-open.org/openc2/jadn/v1.0/cs01/jadn-v1.0-cs01.html) | David Kemp | David Kemp<br>Duncan Sparrell |
-| [jadn-im](https://github.com/oasis-tcs/openc2-jadn-im) | Information Modeling with JADN (CN) | | David Kemp<br>Dan Johnson | David Kemp<br>Dan Johnson<br>Duncan Sparrell<br>David Lemire |
-| [slpf](https://github.com/oasis-tcs/openc2-apsc-stateless-packet-filter) | Stateless Packet Filter | [CS01](https://docs.oasis-open.org/openc2/oc2slpf/v1.0/oc2slpf-v1.0.html) | Duncan Sparrell<br>Alex Everett<br>_Joe Brule_ | David Kemp<br>Alex Everett<br>Duncan Sparrell<br>David Lemire |
-| [sbom](https://github.com/oasis-tcs/openc2-ap-sbom) | Software Bill of Materials | | Duncan Sparrell | Duncan Sparrell<br>Alex Everett<br>David Kemp<br>David Lemire |
-| [sfpf](https://github.com/oasis-tcs/openc2-ap-sfpf) | Stateful Packet Filter | | Alex Everett<br>Vasileios Mavroeidis | Alex Everett<br>David Kemp<br>Vasileios Mavroeidis<br>Duncan Sparrell<br>David Lemire |
-| [ids](https://github.com/oasis-tcs/openc2-ap-ids) | Intrusion Detection Systems | | Duncan Sparrell | Duncan Sparrell<br>David Lemire |
-| [honeypots](https://github.com/oasis-tcs/openc2-ap-honeypots) | Honeypots | | Alex Everett | Alex Everett<br>David Kemp<br>Duncan Sparrell<br>David Lemire |
-| [edr](https://github.com/oasis-tcs/openc2-ap-edr) | Endpoint Detection & Response | | Vasileios Mavroeidis<br>Martin Evandt | Vasileios Mavroeidis<br>Martin Evandt<br>Alex Everett<br>David Kemp<br>Duncan Sparrell<br>David Lemire |
-| [pf](https://github.com/oasis-tcs/openc2-ap-pf) | Packet Filter | | Alex Everett | Alex Everett<br>David Kemp<br>Vasileios Mavroeidis<br>Duncan Sparrell<br>David Lemire |
 | [av](https://github.com/oasis-tcs/openc2-ap-av) | Anti-Virus | | Alex Everett<br>David Kemp<br>Vasileios Mavroeidis | Alex Everett<br>David Kemp<br>Vasileios Mavroeidis<br>Duncan Sparrell<br>David Lemire |
-| [https](https://github.com/oasis-tcs/openc2-impl-https) | HTTPS Transfer Specification | [CS01](https://docs.oasis-open.org/openc2/open-impl-https/v1.0/open-impl-https-v1.0.html) | David Lemire<br>_Joe Brule_ | David Lemire<br>Duncan Sparrell |
-| [mqtt](https://github.com/oasis-tcs/openc2-transf-mqtt) | MQTT Transfer Specification | | David Lemire | David Lemire<br>Duncan Sparrell |
-| [odxl](https://github.com/oasis-tcs/openc2-transf-odxl) | OpenDXL Transfer Specification | | Duncan Sparrell<br>_Scott MacGregor_ | David Lemire<br>Duncan Sparrell |
+| [oc2arch](https://github.com/oasis-tcs/openc2-oc2arch) | Architecture Specification | | Duncan Sparrell<br>Dan Johnson | Duncan Sparrell<br>Dan Johnson<br>Toby Considine<br>David Lemire |
+| [er](https://github.com/oasis-tcs/openc2-ap-er) | Endpoint Response | | Vasileios Mavroeidis<br>Martin Evandt | Vasileios Mavroeidis<br>Martin Evandt<br>Alex Everett<br>David Kemp<br>Duncan Sparrell<br>David Lemire |
+| [honeypots](https://github.com/oasis-tcs/openc2-ap-honeypots) | Honeypots | | Alex Everett | Alex Everett<br>David Kemp<br>Duncan Sparrell<br>David Lemire |
+| [ids](https://github.com/oasis-tcs/openc2-ap-ids) | Intrusion Detection Systems | | Duncan Sparrell | Duncan Sparrell<br>David Lemire |
+| [jadn-im](https://github.com/oasis-tcs/openc2-jadn-im) | JADN Information Modeling (CN) | | David Kemp<br>Dan Johnson | David Kemp<br>Dan Johnson<br>Duncan Sparrell<br>David Lemire |
 | [lc](https://github.com/oasis-tcs/openc2-ap-lc) | Log Collector | | Alex Everett<br>David Kemp | Alex Everett<br>David Kemp<br>Duncan Sparrell<br>David Lemire |
+| [odxl](https://github.com/oasis-tcs/openc2-transf-odxl) | OpenDXL Transfer Specification | | Duncan Sparrell<br>_Scott MacGregor_ | David Lemire<br>Duncan Sparrell |
+| [pf](https://github.com/oasis-tcs/openc2-ap-pf) | Packet Filter | | Alex Everett | Alex Everett<br>David Kemp<br>Vasileios Mavroeidis<br>Duncan Sparrell<br>David Lemire |
+| [sbom](https://github.com/oasis-tcs/openc2-ap-sbom) | Software Bill of Materials | | Duncan Sparrell | Duncan Sparrell<br>Alex Everett<br>David Kemp<br>David Lemire |
+| [swup](https://github.com/oasis-tcs/openc2-ap-swup) | Software Update | | Duncan Sparrell | Duncan Sparrell<br>David Lemire |
+| [sfpf](https://github.com/oasis-tcs/openc2-ap-sfpf) | Stateful Packet Filter | | Alex Everett<br>Vasileios Mavroeidis | Alex Everett<br>David Kemp<br>Vasileios Mavroeidis<br>Duncan Sparrell<br>David Lemire |
 


### PR DESCRIPTION
Overdue update to the work products list. Split table into OASIS published specs vs. work-in-progress. Updated links, added missing documents.