### PR TITLE
capture website maintenance SOP

### DIFF
--- a/openc2-org-maintenance.md
+++ b/openc2-org-maintenance.md
@@ -19,7 +19,7 @@ file](https://github.com/OpenC2-org/openc2-org.github.io/blob/main/README.md).
    the "write team") are assigned to:
    - the TC Co-Chairs
    - the TC Secretary
-   - the website architect[^1]
+   - the website architect [^1]
  - The TC Secretary serves as the Website Editor.
  - Website changes are proposed using GitHub pull requests
    directed to the

--- a/openc2-org-maintenance.md
+++ b/openc2-org-maintenance.md
@@ -44,7 +44,7 @@ file](https://github.com/OpenC2-org/openc2-org.github.io/blob/main/README.md).
    change that would normally go through the working meeting, if
    needed (shouldn't really have any of those).
 
-## Background
+## History
 
 This SOP was originally agreed to by the Implementation
 Considerations Subcommittee in October 2020. With the abolition

--- a/openc2-org-maintenance.md
+++ b/openc2-org-maintenance.md
@@ -30,10 +30,11 @@ file](https://github.com/OpenC2-org/openc2-org.github.io/blob/main/README.md).
    approval.
  - **Moderate** changes should be reviewed and approved by a
    second write team member before merging:
-   - New “OpenC2 in the News” items
-     - Exception: publication of documents by OASIS, which can be
-       posted w/o a review
-   - New / replacement carousel items
+   - New [“OpenC2 in the News”](https://openc2.org/news.html)
+     items (*exception:* information regarding publication of new
+     or updated documents by OASIS can be posted without
+     secondary review)
+   - New / updated / replacement home page carousel items
    - Items of comparable impact to the above
  - The Working Meeting should approve, at any regular meeting:
    - Any **substantive changes** to content

--- a/openc2-org-maintenance.md
+++ b/openc2-org-maintenance.md
@@ -36,7 +36,8 @@ file](https://github.com/OpenC2-org/openc2-org.github.io/blob/main/README.md).
      secondary review)
    - New / updated / replacement home page carousel items
    - Items of comparable impact to the above
- - The Working Meeting should approve, at any regular meeting:
+ - A [Working Meeting](Working-Meeting-Process.md) should
+   approve:
    - Any **substantive changes** to content
    - Any **structural changes** to the site
  - Either TC Co-Chair or the Secretary can approve an “urgent”

--- a/openc2-org-maintenance.md
+++ b/openc2-org-maintenance.md
@@ -1,0 +1,42 @@
+# Maintaining the OpenC2.org Website
+
+This note captures the SOP for approving changes to the
+[openc2.org](https://www.openc2.org) website, which exists to
+support awareness & adoption of OpenC2. 
+
+ - Privileges to commit changes to the OpenC2.org website (AKA,
+   the "write team") are assigned to:
+   - the TC Co-Chairs
+   - the TC Secretary
+   - the website architect[^1]
+ - The TC Secretary serves as the Website Editor
+ - Website changes are proposed using GitHub pull requests
+   directed to the
+   [openc2-org.githib.io](https://github.com/OpenC2-org/openc2-org.github.io)
+   repository. Any TC member can propose website changes.
+ - The Website Editor can directly commit **routine / editorial
+   changes** (typos, wrong dates, broken links).
+ - **Moderate** changes should be reviewed by a second write team
+   member before merging:
+   - New “OpenC2 in the News” items
+     - Exception: publication of documents by OASIS, which can be
+       posted w/o a review
+   - New / replacement carousel items
+   - Items of comparable impact to the above
+ - The Working Meeting should approve, at any regular meeting:
+   - Any **structural changes** to the site
+ - Either TC Co-Chair or the Secretary can approve an “urgent”
+   change that would normally go through the working meeting, if
+   needed (shouldn't really have any of those).
+
+
+This SOP was originally agreed to by the Implementation
+Considerations Subcommittee in October 2020. With the abolition
+of the subcommittees in March 2021, the responsbility for
+approving significant website changes was transferred to the
+[Working Meeting](Working-Meeting-Process.md) process, and the
+text above reflects that change.
+
+[^1]: Support for the OpenC2.org website architecture has been
+provided by AT&T. The architect is not involved in routine
+maintenance of the website.

--- a/openc2-org-maintenance.md
+++ b/openc2-org-maintenance.md
@@ -9,7 +9,7 @@ support awareness & adoption of OpenC2.
    - the TC Co-Chairs
    - the TC Secretary
    - the website architect[^1]
- - The TC Secretary serves as the Website Editor
+ - The TC Secretary serves as the Website Editor.
  - Website changes are proposed using GitHub pull requests
    directed to the
    [openc2-org.githib.io](https://github.com/OpenC2-org/openc2-org.github.io)
@@ -24,6 +24,7 @@ support awareness & adoption of OpenC2.
    - New / replacement carousel items
    - Items of comparable impact to the above
  - The Working Meeting should approve, at any regular meeting:
+   - Any **substantive changes** to content
    - Any **structural changes** to the site
  - Either TC Co-Chair or the Secretary can approve an “urgent”
    change that would normally go through the working meeting, if

--- a/openc2-org-maintenance.md
+++ b/openc2-org-maintenance.md
@@ -4,6 +4,17 @@ This note captures the SOP for approving changes to the
 [openc2.org](https://www.openc2.org) website, which exists to
 support awareness & adoption of OpenC2. 
 
+## Website Information
+
+The OpenC2.org website is hosted using GitHub pages, and is
+composed of a mixture of markdown and HTML content.  Instructions
+for maintaining the website are included in the source
+repository's [README.md
+file](https://github.com/OpenC2-org/openc2-org.github.io/blob/main/README.md).
+
+
+## Maintenance SOP
+
  - Privileges to commit changes to the OpenC2.org website (AKA,
    the "write team") are assigned to:
    - the TC Co-Chairs
@@ -30,6 +41,7 @@ support awareness & adoption of OpenC2.
    change that would normally go through the working meeting, if
    needed (shouldn't really have any of those).
 
+## Background
 
 This SOP was originally agreed to by the Implementation
 Considerations Subcommittee in October 2020. With the abolition

--- a/openc2-org-maintenance.md
+++ b/openc2-org-maintenance.md
@@ -26,9 +26,10 @@ file](https://github.com/OpenC2-org/openc2-org.github.io/blob/main/README.md).
    [openc2-org.githib.io](https://github.com/OpenC2-org/openc2-org.github.io)
    repository. Any TC member can propose website changes.
  - The Website Editor can directly commit **routine / editorial
-   changes** (typos, wrong dates, broken links).
- - **Moderate** changes should be reviewed by a second write team
-   member before merging:
+   changes** (typos, wrong dates, broken links) without further
+   approval.
+ - **Moderate** changes should be reviewed and approved by a
+   second write team member before merging:
    - New “OpenC2 in the News” items
      - Exception: publication of documents by OASIS, which can be
        posted w/o a review


### PR DESCRIPTION
This PR creates a new note in the TC Operations repository to codify an updated version of the OpenC2.org website maintenance process originally agreed to at the October 2020 Implementation Considerations subcommittee meeting.