### PR TITLE
updates to README and gen member info

### DIFF
--- a/General-Member-Info.md
+++ b/General-Member-Info.md
@@ -2,57 +2,68 @@
 #### Information for TC members about the OpenC2 TC's operating routine.
 
 Welcome to the OASIS OpenC2 [Technical Committee
-(TC)](https://www.oasis-open.org/policies-guidelines/oasis-defined-terms-2018-05-22/#dTechnicalCommittee). This brief document provides some basics about our how our TC
-operates:
+(TC)](https://www.oasis-open.org/policies-guidelines/oasis-defined-terms-2018-05-22/#dTechnicalCommittee).
+This brief document provides some basics about our how our TC
+operates. First, some useful links:
 
 * An overview of the TC, including our [standing
   rules](https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=openc2#other),
   can be found at [our home page at
-  OASIS](https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=openc2).   
+  OASIS](https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=openc2).
 * General information about OpenC2 can be found at [OpenC2.org](https://openc2.org/)
 * General information about OASIS can be found on the organization's [About page](https://www.oasis-open.org/org/)
 
-### Meeting Schedules
+## Meeting Schedules
 
-We conduct TC and working meetings using [Lucid
-  Meetings](https://www.lucidmeetings.com). As the OASIS Kavi
-  system is the system of record for TC activities, we schedule
-  our meetings on both the Kavi and Lucid calendars, but you'll
-  only receive one invitations for each meeting series, from
-  Lucid. We schedule our meetings in 6-month blocks, so when we
-  schedule a new block each member receives a brief flurry of
-  email with calendar invitations (5 calendar invites, total).
+The TC conducts our meetings Wednesdays at 11:00 AM Eastern time
+("OpenC2 time"). The monthly meeting schedule is as follows:
 
-  * Wednesdays at 11:00 AM Eastern time is "OpenC2 time"
-    * Our monthly TC meetings on the **third** Wednesday of each
-    month have an "early" (11:00 AM Eastern) and a "late" (9:00
- PM Eastern) session . Per [Standing Rule
-    #6](https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=openc2#other)
-    attendance at either session (which you should record in
-    Kavi) constitutes attendance for that month's meeting. We
-    treat these two sessions as a single meeting for purposes of
-    attendance, [voting
-    rights](https://www.oasis-open.org/policies-guidelines/tc-process-2017-05-26/#membership),
-    meeting minutes, motions voted, etc. This means decisions
-    made at the daytime session are provisional until the evening
-    session is adjourned.
-    * (_As of April 2021 we have a new standing meeting schedule_).
-    The 1st, 2nd, and 4th Wednesdays of each month are used for
-    working meeting to discuss topics related to TC work products
-    and other technical matters. If there are five Wednesdays in a month, there is usually no meeting on the 5th Wednesday.
+| **Day** | **Meeting Type** |
+|:---:|:---:|
+| 1st Wednesday | [Working Meeting](#working-meetings) |
+| 2nd Wednesday | [Working Meeting](#working-meetings) |
+| 3rd Wednesday | [TC Meeting](#tc-technical-committee-meetings) |
+| 4th Wednesday | [Working Meeting](#working-meetings) |
+| 5th Wednesday (if any) | No Meeting |
 
-  * In OASIS Kavi, all meetings are scheduled on the TC calendar (We've eliminated our subcommittees, but they still exist in the system. We no longer use the SC calendars or email lists.)
-  * The entire meeting schedule will be visible on your Lucid
-    dashboard and calendar once you've been added to the OpenC2
-    "room".
-  
-  
-### TC Communications:
-  * In joining our TC you’re automatically subscribed to the TC email list. 
-  * We also have a [Slack community](https://openc2-community.slack.com). 
+We conduct all of our meetings using [Lucid
+Meetings](https://www.lucidmeetings.com). As the OASIS Kavi
+system is the system of record for TC activities, we schedule our
+meetings on both the Kavi and Lucid calendars, but members will
+only receive one invitations for each meeting series, from Lucid.
+Meetings are scheduled in 6-month blocks (March-September, and
+October-April). When a new block is scheduled each member
+receives a brief flurry of email with calendar invitations (5
+calendar invites, total).
+
+## TC (Technical Committee) Meetings
+
+Our monthly TC meetings on the **third** Wednesday of each month
+have an "early" (11:00 AM Eastern) and a "late" (9:00 PM Eastern)
+session . Per [Standing Rule
+#6](https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=openc2#other)
+attendance at either session (which you should record in Kavi)
+constitutes attendance for that month's meeting. We treat these
+two sessions as a single meeting for purposes of attendance,
+[voting
+rights](https://www.oasis-open.org/policies-guidelines/tc-process-2017-05-26/#membership),
+meeting minutes, motions voted, etc. This means decisions made at
+the daytime session are provisional until the evening session is
+adjourned.
+
+## Working Meetings
+
+The 1st, 2nd, and 4th Wednesdays of each month are
+used for working meeting to discuss topics related to TC work
+products and other technical matters.
+
+
+## TC Communications:
+  * In joining our TC you’re automatically subscribed to the TC email list.
+  * We also have a [Slack community](https://openc2-community.slack.com).
 You'll receive an invitation for that as well.
 
-### Work Product Development
+## Work Product Development
 
 * At present all of our work product development is happening on
   [GitHub](https://github.com/), and there is also a collection
@@ -70,14 +81,14 @@ You'll receive an invitation for that as well.
   where we did much of our work in the past; you can find a lot
   of history and reference information there.
 
-### Observers
+## Observers
 
 If you joined the TC as an Observer, we welcome your interest and
 just ask that you respect the [limits of that
 role](https://www.oasis-open.org/committees/roles) and not try to
 actively participate in the activities on the resources above.
 
-### For More Info 
+## For More Info
 Please feel free to contact me if you have any questions or concerns.
 
 #### David Lemire, OpenC2 TC Secretary

--- a/README.md
+++ b/README.md
@@ -33,8 +33,12 @@ This repository includes the following information:
   -- notes about the meeting scheduling process, for reference by
   co-chairs and the TC secretary
 * [Document-Template-2020.md](Document-Template-2020.md) -- a highly condensed version of the new work product outline adopted in late 2020 by OASIS. New work items should use this format (it will be reflected in the starter document provided by OASIS). Existing work items can be reformatted to use this outline; the TC's work product editors consider it an improvement.
-* [FAQ.md](FAQ.md)
-  -- An OpenC2 Frequently Asked Questions list
+* [FAQ-Master.md](FAQ-Master.md) -- A markdown version of the
+  OpenC2 Frequently Asked Questions list. Having the list here in
+  markdown simplifies editing and updating FAQs. The TC Secretary
+  then ports updates to the website's [FAQ
+  page](https://openc2.org/faq.html) following a Markdown-to-HTML
+  conversion.
 * [Other-OpenC2-Work.md](Other-OpenC2-Work.md)
   -- a listing of OpenC2 implementation efforts known to the TC
   outside of those maintained in [open repositories sponsored by


### PR DESCRIPTION
Update README to reflect change in FAQ handling:

- Obsolete FAQ.md has been deleted
- FAQ-Master.md is being used to edit FAQs before porting to OpenC2.org/faq.html

General-Member-Info.md revised for clearer presentation of meeting scheduling and types, to permit linking from FAQ page