### PR TITLE
Update Doc Norms with Namespace Information

### DIFF
--- a/Documentation-Norms.md
+++ b/Documentation-Norms.md
@@ -271,7 +271,9 @@ repositories in use by the OpenC2 TC:
   to
   [commit](https://help.github.com/en/github/getting-started-with-github/github-glossary#commit)
   changes to the repository's contents, be those changes their
-  own work or contributions from other TC members. The assignment of maintainers is discussed in [Section 4.3.2](#432-request-repository-and-assign-maintainers). 
+  own work or contributions from other TC members. The assignment
+  of maintainers is discussed in [Section
+  4.3.2](#432-request-repository-and-assign-maintainers). 
 
 * **TC Working Repos:** In addition to repos specific to
   individual work products, the TC has other repos to support its
@@ -280,7 +282,9 @@ repositories in use by the OpenC2 TC:
   repository to support development of [custom actuator
   profiles](https://github.com/oasis-tcs/openc2-cap) (which may
   eventually turn into TC work products and receive individual
-  repos). This document is stored in the [TC Operationsl repo](https://github.com/oasis-tcs/openc2-tc-ops), which is another "working repo".
+  repos). This document is stored in the [TC Operationsl
+  repo](https://github.com/oasis-tcs/openc2-tc-ops), which is
+  another "working repo".
 
 * **TC Open Repos:**  These are established by the TC to capture
   the development of (primarily) software related to the TC's

--- a/Documentation-Norms.md
+++ b/Documentation-Norms.md
@@ -282,7 +282,7 @@ repositories in use by the OpenC2 TC:
   repository to support development of [custom actuator
   profiles](https://github.com/oasis-tcs/openc2-cap) (which may
   eventually turn into TC work products and receive individual
-  repos). This document is stored in the [TC Operationsl
+  repos). This document is stored in the [TC Operations
   repo](https://github.com/oasis-tcs/openc2-tc-ops), which is
   another "working repo".
 

--- a/Documentation-Norms.md
+++ b/Documentation-Norms.md
@@ -212,6 +212,7 @@ currently performed within the OpenC2 TC, is as follows:
 
 * Identify WP Need
 * Determine WP name
+  * For Actuator Profiles, add the AP to the namespace registry
 * Request starter template and GitHub repository
 * Upload template and configure repository
 * Apply agile, incremental development (cycle)
@@ -220,8 +221,8 @@ currently performed within the OpenC2 TC, is as follows:
 * Conduct Public Review (cycle)
 * CS Approval & Publication
 
-The [Section 4](#4-openc2-tc-work-product-development-process) and the Appendices provide detailed information
-about these steps.
+[Section 4](#4-openc2-tc-work-product-development-process) and
+the Appendices provide detailed information about these steps.
 
 ## 3.4 GitHub, Markdown, Repositories, and Fork & Pull
 

--- a/Documentation-Norms.md
+++ b/Documentation-Norms.md
@@ -383,6 +383,38 @@ three apply the naming conventions described above:
 |  _Specification for Transfer of OpenC2 Messages via OpenDXL_ | transf-odxl | …openc2-transf-odxl |
 |  _Specification for Transfer of OpenC2 Messages via MQTT_ | transf-mqtt | ...-openc2-transf-mqtt |
 
+### 4.2.1 Add Actuator Profile to Namespace Registry
+
+All OpenC2 type definitions are contained in a specification, and
+each specification is assigned a globally-unique namespace in the
+form of a URI. Types in one specification can reference types
+defined in another specification using a namespaced name. As
+OpenC2 uses Actuator Profiles to extend the core language, for
+these extensions to be recognized new APs must be added to the
+Namespace Registry. A more complete discussion of OpenC2
+namespaces can be found in [Appendix
+F](https://docs.oasis-open.org/openc2/oc2arch/v1.0/cs01/oc2arch-v1.0-cs01.html#appendix-f-openc2-namespace-registry)
+of the _OpenC2 Architecture Specification_.
+
+A namespace entry has the following form (excerpt from the
+namespace registry):
+
+| Prop ID | Property Name | OpenC2 Specification                                                                              | NS Prefix | Namespace                                              | Status                                    |
+|---------|---------------|---------------------------------------------------------------------------------------------------|-----------|--------------------------------------------------------|-----------------------------------------
+|         |               | [OpenC2 Language Spec v1.1 Common Types](https://github.com/oasis-tcs/openc2-oc2ls)               | ls:       | http://docs.oasis-open.org/openc2/ns/types/v1.1        | Types section of LS                       |
+| 1024    | slpf          | [Stateless Packet Filtering AP](https://github.com/oasis-tcs/openc2-apsc-stateless-packet-filter) | slpf:     | http://docs.oasis-open.org/openc2/ns/ap-slpf/v1.0      | CSPRD01 2019/05/31 superseded by PF      
+
+
+The namespace registry is maintained in the [GitHub repository
+for the Architecture
+Specification](https://github.com/oasis-tcs/openc2-oc2arch), in
+the file `namespace-registry.md`. When initiating the development
+of a new AP, a pull request should be made to update the
+namespace registry file with a new line representing the new AP;
+the `Prop ID` value for the next AP should be one greater than
+the `Prop ID` of the highest-numbered Standard Actuator Profile,
+and the `Property Name` and `Namespace` values should be set to
+the `<function-shorthand>` for the new AP.
 
 ## 4.3 Establish Development Environment
 

--- a/JADN-and-OpenC2.md
+++ b/JADN-and-OpenC2.md
@@ -28,7 +28,7 @@ of information modeling:
 > _One common problem is the lack of an encoding-independent
    standardization of the information, the so-called information
    model. Another problem is the strong relationship between data
-   formats and the underlying communication architecture_
+   formats and the underlying communication architecture_.
 
 Information models (IMs) are used to define and generate physical
 data models, validate information instances, and enable lossless
@@ -207,13 +207,17 @@ interface to the actuator. Just as with the OpenC2 Language, APs
 are intended to be defined in implementation-independent terms so
 that the exchange of commands and responses may be supported
 using different protocols or transfer encodings while retaining a
-common and consistent meaning. The IM for an OpenC2 AP is
-therefore both a subset of the OpenC2 Language IM (as not all
-actions or targets will apply to any individual actuator) and an
-extension of it (to define actuator-specific elements). A feature
-of every AP is the mapping of supported action / target
-combinations to specify the set of commands valid for that
-actuator. The [Stateless Packet Filtering
+common and consistent meaning. 
+
+Developing an OpenC2 AP is begun by developing an appropriate IM
+for that AP, ideally using JADN. An AP's IM is both a subset of
+the OpenC2 Language IM (as not all of the actions or targets in
+the language will apply to any individual actuator) and an
+extension of it (as most APs need to define actuator-specific
+elements). A feature of every AP is the identification of
+supported action / target combinations to specify the set of
+commands valid for that actuator. As an example, the [Stateless
+Packet Filtering
 AP](https://docs.oasis-open.org/openc2/oc2slpf/v1.0/oc2slpf-v1.0.html)
 includes the following command matrix (section 2.3, actions are
 across the top, targets are down the left side including an
@@ -222,7 +226,7 @@ AP-specific target [`slpf:rule_number`]):
 > ![SLPF AP Command Matrix](images/slfp-ap-cmd-matrix.png)
 
 As with the Language Specification, the AP is actually defined by
-its underlying IM:
+its underlying IM, from which the command matrix is derived:
 
 ```
 Action-Targets = Map  // Targets applicable to each action


### PR DESCRIPTION
Per discussion at the 25 Jan 2023 working meeting, this PR updates _Documentation Norms_ to reflect the namespace registry and the need to registry new Actuator Profiles.

This PR also includes minor changes to the JADN and OpenC2 document to improve clarity.