### PR TITLE
Updates to General Member Info

### DIFF
--- a/General-Member-Info.md
+++ b/General-Member-Info.md
@@ -22,7 +22,7 @@ The TC conducts our meetings Wednesdays at 11:00 AM Eastern time
 |:---:|:---:|
 | 1st Wednesday | [Working Meeting](#working-meetings) |
 | 2nd Wednesday | [Working Meeting](#working-meetings) |
-| 3rd Wednesday | [TC Meeting](#tc-technical-committee-meetings) |
+| 3rd Wednesday | [TC Meeting](#tc-technical-committee-meetings)<br>(2 sessions) |
 | 4th Wednesday | [Working Meeting](#working-meetings) |
 | 5th Wednesday (if any) | No Meeting |
 
@@ -30,52 +30,51 @@ We conduct all of our meetings using [Lucid
 Meetings](https://www.lucidmeetings.com). As the OASIS Kavi
 system is the system of record for TC activities, we schedule our
 meetings on both the Kavi and Lucid calendars, but members will
-only receive one invitations for each meeting series, from Lucid.
-Meetings are scheduled in 6-month blocks (March-September, and
-October-April). When a new block is scheduled each member
-receives a brief flurry of email with calendar invitations (5
-calendar invites, total).
+only receive one invitation for each meeting series, from Lucid.
+Meetings are usually scheduled in 6-month blocks
+(March-September, and October-April). When a new block is
+scheduled each member receives a brief flurry of email with
+calendar invitations (5 calendar invites, total).
 
 ## TC (Technical Committee) Meetings
 
 Our monthly TC meetings on the **third** Wednesday of each month
-have an "early" (11:00 AM Eastern) and a "late" (9:00 PM Eastern)
-session. The same agenda is used for both sessions, and the two
-sessions are treated as a single meeting (see [Standing Rule
+have an "early" (11:00 AM Eastern) sesion and a "late" (9:00 PM
+Eastern) session. The same agenda is used for both sessions, and
+the two sessions are treated as a single meeting (see [Standing Rule
 #6](https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=openc2#other))
-for purposes of attendance, meeting minutes, [voting
-rights](https://www.oasis-open.org/policies-guidelines/tc-process-2017-05-26/#membership),
+for purposes of attendance, [voting rights](https://www.oasis-open.org/policies-guidelines/tc-process-2017-05-26/#membership),
 meeting minutes, motions voted, etc. This also means decisions
 made at the daytime session are provisional until the evening
 session is adjourned.
 
 ## Working Meetings
 
-The 1st, 2nd, and 4th Wednesdays of each month are
-used for working meeting to discuss topics related to TC work
-products and other technical matters.
+The 1st, 2nd, and 4th Wednesdays of each month are used for
+working meeting to discuss topics related to TC work products and
+other technical matters.
 
 
 ## TC Communications:
-  * In joining our TC you’re automatically subscribed to the TC email list.
-  * We also have a [Slack community](https://openc2-community.slack.com).
-You'll receive an invitation for that as well.
+  * By joining our TC you’re automatically subscribed to the OASIS TC email list.
+  * Communicationa about [Work Products](https://www.oasis-open.org/policies-guidelines/oasis-defined-terms-2018-05-22/#dWorkProduct) is typically done either:
+    * in Working Meetings, or
+    * via GitHub [issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-issues) and [pull requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests).
 
 ## Work Product Development
 
 * At present all of our work product development is happening on
-  [GitHub](https://github.com/), and there is also a collection
-  of open repositories there with OpenC2 implementations. Links:
-  * [Work product repos](https://github.com/oasis-tcs?utf8=%E2%9C%93&q=openc2&type=&language=): specifications and related documents
-  * [Open repos](https://github.com/oasis-open?utf8=%E2%9C%93&q=openc2-&type=&language=): software contributions
+  [GitHub](https://github.com/) using [Fork & Pull](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/getting-started/about-collaborative-development-models) model.  There is also a collection
+  of open GitHub repositories with OpenC2 implementations. Links:
+  * [Work product repos:](https://github.com/oasis-tcs?utf8=%E2%9C%93&q=openc2&type=&language=) specifications and related documents
+  * [Open repos:](https://github.com/oasis-open?utf8=%E2%9C%93&q=openc2-&type=&language=) software contributions
 * The TC's [Documentation Norms](Documentation-Norms.md) provides
   a great deal of information regarding our approach to work
   product development. This includes [information on using
   GitHub](https://github.com/dlemire60/openc2-tc-ops/blob/new-battle-rhythm/Documentation-Norms.md#appendix-b-getting-comfortable-with-github)
   if you aren't familiar with it.
 
-* The TC also has a [Google
-  Drive](https://drive.google.com/drive/u/1/folders/0ByY7rMsnC7rrY1JEMlBLckNXTG8)
+* The TC also has a [Google Drive](https://drive.google.com/drive/u/1/folders/0ByY7rMsnC7rrY1JEMlBLckNXTG8)
   where we did much of our work in the past; you can find a lot
   of history and reference information there.
 


### PR DESCRIPTION
Primary change is to remove mention of Slack community.

Other misc. updates to add links, improve presentation, add info about communications via working meetings and GH issues and PRs.